### PR TITLE
Add inter-turbine filtering capability related to FLASC PR #74

### DIFF
--- a/{{cookiecutter.project_slug}}/python/raw_data_processing/northing_calibration.ipynb
+++ b/{{cookiecutter.project_slug}}/python/raw_data_processing/northing_calibration.ipynb
@@ -25,7 +25,10 @@
     "\n",
     "from flasc.turbine_analysis import northing_offset as nof\n",
     "from flasc import floris_tools as ftools\n",
-    "from flasc.dataframe_operations import dataframe_manipulations as dfm\n",
+    "from flasc.dataframe_operations import (\n",
+    "    dataframe_manipulations as dfm,\n",
+    "    dataframe_filtering as dff,\n",
+    ")\n",
     "from flasc.energy_ratio import energy_ratio_wd_bias_estimation as best\n",
     "# from flasc import time_operations as fto\n",
     "from flasc import optimization as flopt\n",
@@ -127,7 +130,13 @@
     "    df=df_scada,\n",
     "    fi=fi,\n",
     "    plot_figure=True\n",
-    ")"
+    ")\n",
+    "print(turb_wd_consistency)\n",
+    "\n",
+    "# Mark wind direction measurements of turbines with inconsistent calibration as faulty\n",
+    "faulty_turbines = [not s == \"clean\" for s in turb_wd_consistency]\n",
+    "for ti in np.where(faulty_turbines)[0]:\n",
+    "    df_scada[\"wd_{:03d}\".format(ti)] = np.nan"
    ]
   },
   {
@@ -153,9 +162,6 @@
     "\n",
     "    # Calculate which turbines are upstream for every wind direction\n",
     "    df_upstream = ftools.get_upstream_turbs_floris(fi, wd_step=2.0)\n",
-    "\n",
-    "    # # Specify local directory\n",
-    "    root_path = os.getcwd()\n",
     "\n",
     "    # We assign the total datasets \"true\" wind direction as equal to the wind\n",
     "    # direction of the turbine which we want to perform northing calibration\n",
@@ -340,8 +346,7 @@
     "    return wd_bias_list\n",
     "\n",
     "wd_bias_list = estimate_biases_with_reference_wd(df_scada, fi, wd_ref)\n",
-    "print(\"Wind direction biases: {}\".format(wd_bias_list))\n",
-    "\n"
+    "print(\"Wind direction biases: {}\".format(wd_bias_list))\n"
    ]
   },
   {
@@ -349,8 +354,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# **Step 5**: Correct and save data\n",
-    "The final step is to apply the northing corrections directly on the data and save it for further analysis. # This script now removes the estimated wind direction bias for every wind direction signal. We then save this bias-corrected dataframe to our local path folder for then to use in further data analysis, e.g., model validation, wake loss estimation, turbine monitoring."
+    "# **Step 5**: Correct turbine wind directions for bias\n",
+    "The next step is to apply the northing corrections directly on the data."
    ]
   },
   {
@@ -376,12 +381,77 @@
     "\n",
     "\n",
     "# Get bias corrections\n",
-    "df_out = apply_bias_corrections(df_scada, wd_bias_list)\n",
+    "print(\"wd_bias_list: {}\".format(wd_bias_list))\n",
+    "df_scada = apply_bias_corrections(df_scada, wd_bias_list)\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# **Step 6**: Deal with inter-turbine faults\n",
+    "Deal with faults at one turbine causing issues at another turbine. For example, if a turbine is shedding a wake on a second turbine, then for a fair comparison both of these two turbines should be operating normally. If the upstream turbine is curtailed or offline, the power production of the downstream turbine also changes. Hence, if we are unsure about the operating mode of one machine, we cannot make accurate FLORIS predictions on the second turbine either. In this scenario, we would classify the second turbine's measurement as faulty too, because of this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def filter_for_faulty_waking_turbines(df):\n",
+    "    # Determine which turbines impact which other turbines through their wakes\n",
+    "    print(\"Calculating the 'df_impacting_turbines' matrix...\")\n",
+    "    df_impacting_turbines = ftools.get_all_impacting_turbines(\n",
+    "        fi_in=fi,\n",
+    "        wd_array=np.arange(0.0, 360.0, 3.0),\n",
+    "        change_threshold=0.005,\n",
+    "        ws_test=9.0,\n",
+    "    )\n",
+    "    print(df_impacting_turbines)\n",
     "\n",
+    "    # Filter the measurements for each turbine: make sure all other turbines affecting this turbine's\n",
+    "    # power production are marked as good measurements. If they are not, then classify this turbine's\n",
+    "    # measurement as faulty too.\n",
+    "    num_turbines = dfm.get_num_turbines(df)\n",
+    "    for ti in range(num_turbines):\n",
+    "        # Assign a reference wind direction for this turbine. In this case,\n",
+    "        # we have such a small farm so we assume that the farm average wind\n",
+    "        # direction of representative of every turbine.\n",
+    "        df = dfm.set_wd_by_all_turbines(df)\n",
+    "\n",
+    "        df_scada = dff.filter_df_by_faulty_waking_turbines(\n",
+    "            df=df,\n",
+    "            ti=ti,\n",
+    "            df_impacting_turbines=df_impacting_turbines,\n",
+    "            verbose=True,\n",
+    "        )\n",
+    "    \n",
+    "    return df_scada\n",
+    "\n",
+    "df_scada = filter_for_faulty_waking_turbines(df=df_scada)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# **Step 7**: Save the processed data\n",
+    "We save the bias-corrected dataframe to our local path folder for then to use in further data analysis, e.g., model validation, wake loss estimation, turbine monitoring."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Save the dataframe with corrected wind directions\n",
     "print(\"Saving dataframes as .ftr files\")\n",
     "fout = os.path.join(root_path, \"postprocessed\", \"df_scada_data_600s_filtered_and_northing_calibrated.ftr\")\n",
-    "df_out.to_feather(fout)\n",
+    "df_scada.to_feather(fout)\n",
     "print(\"Finished processing. Saved the df as '{:s}'.\".format(os.path.relpath(fout)))"
    ]
   },

--- a/{{cookiecutter.project_slug}}/python/raw_data_processing/northing_calibration.ipynb
+++ b/{{cookiecutter.project_slug}}/python/raw_data_processing/northing_calibration.ipynb
@@ -430,7 +430,7 @@
     "    \n",
     "    return df_scada\n",
     "\n",
-    "df_scada = filter_for_faulty_waking_turbines(df=df_scada)"
+    "df_scada = filter_for_faulty_impacting_turbines(df=df_scada)"
    ]
   },
   {

--- a/{{cookiecutter.project_slug}}/python/raw_data_processing/northing_calibration.ipynb
+++ b/{{cookiecutter.project_slug}}/python/raw_data_processing/northing_calibration.ipynb
@@ -391,7 +391,9 @@
    "metadata": {},
    "source": [
     "# **Step 6**: Deal with inter-turbine faults\n",
-    "Deal with faults at one turbine causing issues at another turbine. For example, if a turbine is shedding a wake on a second turbine, then for a fair comparison both of these two turbines should be operating normally. If the upstream turbine is curtailed or offline, the power production of the downstream turbine also changes. Hence, if we are unsure about the operating mode of one machine, we cannot make accurate FLORIS predictions on the second turbine either. In this scenario, we would classify the second turbine's measurement as faulty too, because of this."
+    "Deal with faults at one turbine causing issues at another turbine. For example, if a turbine is shedding a wake on a second turbine, then for a fair comparison both of these two turbines should be operating normally. If the upstream turbine is curtailed or offline, the power production of the downstream turbine also changes. Hence, if we are unsure about the operating mode of one machine, we cannot make accurate FLORIS predictions on the second turbine either. In this scenario, we would classify the second turbine's measurement as faulty too, because of this.\n",
+    "\n",
+    "Note that it is important to not run this cell multiple times. If you do so, you will cascade errors downstream which will unnecessarily mark otherwise OK measurements as faulty. See the discussion and the comment by @paulf81 in https://github.com/NREL/flasc/pull/74."
    ]
   },
   {


### PR DESCRIPTION
This PR adds an additional step in the data processing in which turbines are filtered for the behavior of neighboring (impacting) turbines. If a turbine that is waking another turbine is reporting a NaN, then the other turbine is also assigned to a NaN value. Previously, FLORIS assumed normal behavior for all turbines with NaNs which is an unrealistic assumption to make.

This step reduces the data pool but further ensures we are comparing apples to apples.

This is related to [PR #74 from FLASC](https://github.com/NREL/flasc/pull/74).