### PR TITLE
Feature: add cache and allow repeated cell evaluations in Jupyter notebooks

### DIFF
--- a/{{cookiecutter.project_slug}}/python/raw_data_processing/filter_ws_power_curves.ipynb
+++ b/{{cookiecutter.project_slug}}/python/raw_data_processing/filter_ws_power_curves.ipynb
@@ -88,18 +88,6 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "def format_dataframes(df_scada, df_metmast):\n",
     "    # Format columns and data. The operations required differ per dataset.\n",

--- a/{{cookiecutter.project_slug}}/python/raw_data_processing/filter_ws_power_curves.ipynb
+++ b/{{cookiecutter.project_slug}}/python/raw_data_processing/filter_ws_power_curves.ipynb
@@ -343,7 +343,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# **Step 5**: Plot faults vs. the layout"
+    "# **Step 3**: Plot faults vs. the layout"
    ]
   },
   {

--- a/{{cookiecutter.project_slug}}/python/raw_data_processing/filter_ws_power_curves.ipynb
+++ b/{{cookiecutter.project_slug}}/python/raw_data_processing/filter_ws_power_curves.ipynb
@@ -68,10 +68,10 @@
     "    df_scada_raw = df_scada_raw.drop(df_scada_raw.columns[0], axis=1)\n",
     "    df_metmast_raw = df_metmast_raw.drop(df_metmast_raw.columns[0], axis=1)\n",
     "\n",
-    "    print(\"Columns available in df_scada_raw: {}.\".format(list(df_scada_raw.columns)))\n",
     "    return df_scada_raw, df_metmast_raw\n",
     "\n",
-    "df_scada_raw, df_metmast_raw = load_data()"
+    "df_scada_raw, df_metmast_raw = load_data()\n",
+    "print(\"Columns available in df_scada_raw: {}.\".format(list(df_scada_raw.columns)))"
    ]
   },
   {
@@ -80,7 +80,7 @@
    "metadata": {},
    "source": [
     "# **Step 1**: Format to common FLASC format\n",
-    "Now create a copy of df_scada_raw and df_metmast_raw which we can manipulate and filter."
+    "Format df_scada to pour the dataframe into the common FLASC format. For example, wind speeds are columns denoted by ws_{ti}, with {ti} the turbine number with prevailing zeros. Hence, for wind speed for the third turbine is defined by ws_002, and the power production of the thirteenth turbine is defined by pow_012."
    ]
   },
   {
@@ -88,19 +88,12 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Now make a copy of the raw data files for processing and manipulation\n",
-    "df_scada = df_scada_raw.copy()\n",
-    "df_metmast = df_metmast_raw.copy()"
-   ]
+   "source": []
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Format df_scada to pour the dataframe into the common FLASC format. For example, wind speeds are columns denoted by ws_{ti}, with {ti} the turbine number with prevailing zeros. Hence, for wind speed for the third turbine is defined by ws_002, and the power production of the thirteenth turbine is defined by pow_012."
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
@@ -149,12 +142,14 @@
     "    # Sort dataframe and save\n",
     "    df_scada = df_scada.sort_values(axis=0, by=\"time\")\n",
     "    df_scada = df_scada.reset_index(drop=True)\n",
-    "    print(\"Columns available in df_scada: {}.\".format(list(df_scada.columns)))\n",
     "\n",
     "    return df_scada, df_metmast\n",
     "\n",
-    "print(df_scada.columns)\n",
-    "df_scada, df_metmast = format_dataframes(df_scada, df_metmast)"
+    "df_scada_formatted, df_metmast_formatted = format_dataframes(\n",
+    "    df_scada=df_scada_raw.copy(),\n",
+    "    df_metmast=df_metmast_raw.copy()\n",
+    ")\n",
+    "print(\"Columns available in df_scada_formatted: {}.\".format(list(df_scada_formatted.columns)))"
    ]
   },
   {
@@ -350,7 +345,9 @@
     "    return df, df_pow_curve\n",
     "\n",
     "\n",
-    "df_scada, df_pow_curve = filter_by_ws_pow_curve(df=df_scada)"
+    "df_scada_filtered, df_pow_curve = filter_by_ws_pow_curve(\n",
+    "    df=df_scada_formatted.copy()\n",
+    ")"
    ]
   },
   {
@@ -358,7 +355,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# **Step 3**: Plot faults vs. the layout"
+    "# **Step 5**: Plot faults vs. the layout"
    ]
   },
   {
@@ -412,7 +409,7 @@
     "    os.makedirs(out_path, exist_ok=True)\n",
     "    plt.savefig(fig_out, dpi=300)\n",
     "\n",
-    "plot_faults_vs_layout(df_scada)"
+    "plot_faults_vs_layout(df_scada_filtered)"
    ]
   },
   {
@@ -431,7 +428,7 @@
    "source": [
     "root_path = os.getcwd()\n",
     "fout = os.path.join(root_path, \"postprocessed\", \"df_scada_600s_wspowfiltered.ftr\")\n",
-    "df_scada.to_feather(fout)\n",
+    "df_scada_filtered.to_feather(fout)\n",
     "print(\"File saved to '{:s}'.\".format(os.path.relpath(fout)))"
    ]
   },

--- a/{{cookiecutter.project_slug}}/python/raw_data_processing/northing_calibration.ipynb
+++ b/{{cookiecutter.project_slug}}/python/raw_data_processing/northing_calibration.ipynb
@@ -77,8 +77,8 @@
     "\n",
     "    return df_scada\n",
     "\n",
-    "df_scada = load_data()\n",
-    "df_scada[\"ti\"] = 0.06  # Assume a certain ambient turbulence intensity"
+    "df_scada_northing_uncalibrated = load_data()\n",
+    "df_scada_northing_uncalibrated[\"ti\"] = 0.06  # Assume a certain ambient turbulence intensity"
    ]
   },
   {
@@ -126,8 +126,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Create a copy in which we mark the wd measurements of turbines with northing drift  as faulty\n",
+    "df_scada_marked_faulty_northing_drift = df_scada_northing_uncalibrated.copy() \n",
+    "\n",
     "turb_wd_consistency = nof.crosscheck_northing_offset_consistency(\n",
-    "    df=df_scada,\n",
+    "    df=df_scada_marked_faulty_northing_drift,\n",
     "    fi=fi,\n",
     "    plot_figure=True\n",
     ")\n",
@@ -136,7 +139,7 @@
     "# Mark wind direction measurements of turbines with inconsistent calibration as faulty\n",
     "faulty_turbines = [not s == \"clean\" for s in turb_wd_consistency]\n",
     "for ti in np.where(faulty_turbines)[0]:\n",
-    "    df_scada[\"wd_{:03d}\".format(ti)] = np.nan"
+    "    df_scada_marked_faulty_northing_drift[\"wd_{:03d}\".format(ti)] = np.nan"
    ]
   },
   {
@@ -281,7 +284,7 @@
     "\n",
     "# Calculate optimal bias for the first clean turbine, covering all possibilities (from -180 deg to +180 deg offset)\n",
     "wd_bias = get_bias_for_single_turbine(\n",
-    "    df=df_scada,\n",
+    "    df=df_scada_marked_faulty_northing_drift,\n",
     "    fi=fi,\n",
     "    ti=first_clean_turbid,\n",
     "    opt_search_range=(-180.0, 180.0),\n",
@@ -290,7 +293,7 @@
     "print(\"WD bias for first clean turbine: {:.3f} deg\".format(wd_bias))\n",
     "\n",
     "# Now calculate the northing-bias-corrected wind direction for this turbine and call it our reference\n",
-    "wd_ref = wrap_360(df_scada[\"wd_{:03d}\".format(first_clean_turbid)] - wd_bias)"
+    "wd_ref = wrap_360(df_scada_marked_faulty_northing_drift[\"wd_{:03d}\".format(first_clean_turbid)] - wd_bias)"
    ]
   },
   {
@@ -345,7 +348,7 @@
     "\n",
     "    return wd_bias_list\n",
     "\n",
-    "wd_bias_list = estimate_biases_with_reference_wd(df_scada, fi, wd_ref)\n",
+    "wd_bias_list = estimate_biases_with_reference_wd(df_scada_marked_faulty_northing_drift, fi, wd_ref)\n",
     "print(\"Wind direction biases: {}\".format(wd_bias_list))\n"
    ]
   },
@@ -382,7 +385,10 @@
     "\n",
     "# Get bias corrections\n",
     "print(\"wd_bias_list: {}\".format(wd_bias_list))\n",
-    "df_scada = apply_bias_corrections(df_scada, wd_bias_list)\n"
+    "df_scada_northing_calibrated = apply_bias_corrections(\n",
+    "    df_scada=df_scada_marked_faulty_northing_drift.copy(),\n",
+    "    wd_bias_list=wd_bias_list\n",
+    ")\n"
    ]
   },
   {
@@ -391,9 +397,7 @@
    "metadata": {},
    "source": [
     "# **Step 6**: Deal with inter-turbine faults\n",
-    "Deal with faults at one turbine causing issues at another turbine. For example, if a turbine is shedding a wake on a second turbine, then for a fair comparison both of these two turbines should be operating normally. If the upstream turbine is curtailed or offline, the power production of the downstream turbine also changes. Hence, if we are unsure about the operating mode of one machine, we cannot make accurate FLORIS predictions on the second turbine either. In this scenario, we would classify the second turbine's measurement as faulty too, because of this.\n",
-    "\n",
-    "Note that it is important to not run this cell multiple times. If you do so, you will cascade errors downstream which will unnecessarily mark otherwise OK measurements as faulty. See the discussion and the comment by @paulf81 in https://github.com/NREL/flasc/pull/74."
+    "Deal with faults at one turbine causing issues at another turbine. For example, if a turbine is shedding a wake on a second turbine, then for a fair comparison both of these two turbines should be operating normally. If the upstream turbine is curtailed or offline, the power production of the downstream turbine also changes. Hence, if we are unsure about the operating mode of one machine, we cannot make accurate FLORIS predictions on the second turbine either. In this scenario, we would classify the second turbine's measurement as faulty too, because of this."
    ]
   },
   {
@@ -402,7 +406,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def filter_for_faulty_waking_turbines(df):\n",
+    "def filter_for_faults_in_impacting_turbines(df):\n",
     "    # Determine which turbines impact which other turbines through their wakes\n",
     "    print(\"Calculating the 'df_impacting_turbines' matrix...\")\n",
     "    df_impacting_turbines = ftools.get_all_impacting_turbines(\n",
@@ -423,7 +427,7 @@
     "        # direction of representative of every turbine.\n",
     "        df = dfm.set_wd_by_all_turbines(df)\n",
     "\n",
-    "        df_scada = dff.filter_df_by_faulty_waking_turbines(\n",
+    "        df_scada = dff.filter_df_by_faulty_impacting_turbines(\n",
     "            df=df,\n",
     "            ti=ti,\n",
     "            df_impacting_turbines=df_impacting_turbines,\n",
@@ -432,7 +436,9 @@
     "    \n",
     "    return df_scada\n",
     "\n",
-    "df_scada = filter_for_faulty_impacting_turbines(df=df_scada)"
+    "df_scada_northing_calibrated_interturbine_filtered = filter_for_faults_in_impacting_turbines(\n",
+    "    df=df_scada_northing_calibrated.copy()\n",
+    ")"
    ]
   },
   {
@@ -453,7 +459,7 @@
     "# Save the dataframe with corrected wind directions\n",
     "print(\"Saving dataframes as .ftr files\")\n",
     "fout = os.path.join(root_path, \"postprocessed\", \"df_scada_data_600s_filtered_and_northing_calibrated.ftr\")\n",
-    "df_scada.to_feather(fout)\n",
+    "df_scada_northing_calibrated_interturbine_filtered.to_feather(fout)\n",
     "print(\"Finished processing. Saved the df as '{:s}'.\".format(os.path.relpath(fout)))"
    ]
   },


### PR DESCRIPTION
Currently, when processing raw data using the Jupyter notebooks, `df_scada` is passed around and manipulated directly. This means that users that run cells multiple times may cascade outlier detection and thereby mark more measurements than necessary as faulty. 

In FLASC, this was previously solved by having each data manipulation as a separate function, where the input and output are saved as `.ftr` files that function as separate variables, i.e., the output does not overwrite the input. See https://github.com/NREL/flasc/tree/main/examples/raw_data_processing. This pull request reintroduces this by having independent variables for `df_scada` in each cell which then are passed around in the right order. This allows users to run cells multiple times without cascading outlier detection.

The only disadvantage of this is additional memory usage. This may be resolved at some point by introducing `polars` in `FLASC`, see https://github.com/NREL/flasc/discussions/69.